### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "betfair-adapter"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "betfair-types",
  "eyre",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-cert-gen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "eyre",
  "rand",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-rpc-server-mock"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "betfair-adapter",
  "betfair-types",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "backoff",
  "betfair-adapter",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-server-mock"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "betfair-adapter",
  "betfair-rpc-server-mock",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "betfair-types",
  "chrono",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-typegen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "betfair-xml-parser",
  "eyre",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "betfair-typegen",
  "chrono",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-xml-parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "log",
  "rstest",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-market"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-orders"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -3409,7 +3409,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "betfair-cert-gen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/*", "xtask"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Roberts Pumpurs <roberts@pumpurlabs.com>"]
 repository = "https://github.com/roberts-pumpurs/betfair-adapter-rs"
 homepage = "https://github.com/roberts-pumpurs/betfair-adapter-rs"

--- a/crates/betfair-adapter/CHANGELOG.md
+++ b/crates/betfair-adapter/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.1.0...betfair-adapter-v0.1.1) - 2024-12-24
+
+### Added
+
+- betfair requests can be made concurrently via request objects
+- :art: Added xtask subscribe to market command (#7)
+- example on how to connnect to betfair
+- refactored stream api
+- can instantiate stream api by just importing a trait
+- rpc server mock separated out
+- created handicap type
+- wrapper/helper for subscribing to markets
+- stream API can do a handshake
+- stream api can connect
+- custom types for some specific betfair types
+- stream api tls and non-tls connections
+- initial stream api processor
+
+### Fixed
+
+- re-export internal request types
+- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
+- misbehaving heartbeat strategy
+
+### Other
+
+- add description to all packages
+- update cargo toml for all crates
+- use arcs for wrapping strings (temp)
+- remove unnecessary `async` keywords
+- `build_request` is no longer async
+- cargo xtask fmt
+- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
+- new ci
+- identity parsing tests
+- remove circular dependencies
+- cargo xtask fmt
+- betfair urls have default jurisdiction
+- applying clippy lints
+- fixing clippy lints
+- remove unused dependencies
+- improved error handling and added sesseion token refresh logic
+- cargo fmt & cargo clippy
+- added utilities for wiring up mocks
+- added utilities for wiring up mocks
+- fix broken tests
+- rename "rpc adapter" to just "adapter"
+- readme update
+- cleanup
+- update readme, docs and templates
+- root for custom Betfair adapter

--- a/crates/betfair-cert-gen/CHANGELOG.md
+++ b/crates/betfair-cert-gen/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.1.0...betfair-cert-gen-v0.1.1) - 2024-12-24
+
+### Added
+
+- utilities for generating certificates for Betfair
+
+### Fixed
+
+- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
+- :construction: Fix linting warnings in the codebase (#4)
+
+### Other
+
+- add description to all packages
+- update cargo toml for all crates
+- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
+- new ci
+- cargo xtask fmt
+- fixing clippy lints
+- readme update
+- cleanup
+- update readme, docs and templates
+- root for custom Betfair adapter

--- a/crates/betfair-rpc-server-mock/CHANGELOG.md
+++ b/crates/betfair-rpc-server-mock/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.1.0...betfair-rpc-server-mock-v0.1.1) - 2024-12-24
+
+### Added
+
+- refactored stream api
+- can instantiate stream api by just importing a trait
+- rpc server mock separated out
+
+### Fixed
+
+- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
+
+### Other
+
+- add description to all packages
+- update cargo toml for all crates
+- use arcs for wrapping strings (temp)
+- remove unnecessary `async` keywords
+- fix broken test
+- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
+- new ci
+- add utilities to model errror responses
+- remove circular dependencies
+- rpc mock will validate login credentials
+- applying clippy lints
+- fixing clippy lints
+- remove unused dependencies
+- fix broken test
+- added utilities for wiring up mocks
+- added utilities for wiring up mocks
+- added utilities for wiring up mocks
+- readme update
+- cleanup
+- update readme, docs and templates
+- root for custom Betfair adapter

--- a/crates/betfair-stream-api/CHANGELOG.md
+++ b/crates/betfair-stream-api/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.1.0...betfair-stream-api-v0.1.1) - 2024-12-24
+
+### Added
+
+- can build local cache from data
+- expose cache primitives
+- getter for runners and market_id in OrderBookCache
+- using `backoff` crate for retrying the connection to the stream
+- utilities for generating certificates for Betfair
+- failure to authenticate will trigger a metadata update
+- proper handling for tls connector
+- example on how to connnect to betfair
+- refactored stream api
+- can instantiate stream api by just importing a trait
+- rpc server mock separated out
+- order subscriber specialization
+- re-expose internal cache types
+- created handicap type
+- fix auto-reconnection
+- wrapper/helper for subscribing to markets
+- cache for stream listener
+- init order book cache
+- stream market book cache
+- available cache structure
+- stream API can do a handshake
+- stream api can connect
+- stream api tls and non-tls connections
+- initial stream api processor
+- new empty crate for betfair stream api
+
+### Fixed
+
+- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
+- misbehaving heartbeat strategy
+
+### Other
+
+- add description to all packages
+- update cargo toml for all crates
+- use arcs for wrapping strings (temp)
+- expose the available book data
+- minor cleanup
+- bump deps
+- cargo xtask fmt
+- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
+- typo fix
+- new ci
+- remove circular dependencies
+- cargo xtask fmt
+- orderbok cache refactor
+- using pin-project crate
+- remove unnecessary async
+- apply clippy suggestions
+- applying clippy lints
+- fixing clippy lints
+- fix typos
+- remove unused dependencies
+- cargo xtask fmt
+- remove redundant broadcast channel
+- add tests for stream api connection
+- cleaned up cache loop
+- improved error handling and added sesseion token refresh logic
+- handshake handled by a custom stream impl
+- stream api folder structure
+- cargo fmt & cargo clippy
+- tls stream will no longer be multiplexed
+- added utilities for wiring up mocks
+- exposing order cache
+- exposing order cache
+- init background reconnection structure
+- fix broken tests
+- type renaming
+- simplified `raw_stream` code
+- tests for market book cache
+- wip subscribe
+- cargo make fmt
+- fix broken tests
+- wip
+- readme update
+- cleanup
+- update readme, docs and templates
+- root for custom Betfair adapter

--- a/crates/betfair-stream-server-mock/CHANGELOG.md
+++ b/crates/betfair-stream-server-mock/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-server-mock-v0.1.0...betfair-stream-server-mock-v0.1.1) - 2024-12-24
+
+### Added
+
+- stream api will not crash if certificate cell is initialized
+- proper handling for tls connector
+- refactored stream api
+- created handicap type
+- fix auto-reconnection
+- wrapper/helper for subscribing to markets
+
+### Fixed
+
+- :bug: Fix for the default feature of integration-test (#9)
+- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
+- misbehaving heartbeat strategy
+
+### Other
+
+- add description to all packages
+- update cargo toml for all crates
+- use arcs for wrapping strings (temp)
+- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
+- new ci
+- remove circular dependencies
+- fixing clippy lints
+- remove unused dependencies
+- stream api folder structure
+- cargo fmt & cargo clippy
+- cargo make fmt
+- fix broken tests
+- readme update
+- cleanup
+- update readme, docs and templates
+- root for custom Betfair adapter

--- a/crates/betfair-stream-types/CHANGELOG.md
+++ b/crates/betfair-stream-types/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.1.0...betfair-stream-types-v0.1.1) - 2024-12-24
+
+### Added
+
+- created handicap type
+- wrapper/helper for subscribing to markets
+- cache for stream listener
+- init order book cache
+- stream market book cache
+- custom types for some specific betfair types
+- initial stream api processor
+- streaming API types
+
+### Fixed
+
+- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
+- :construction: Fix linting warnings in the codebase (#4)
+
+### Other
+
+- use local readme
+- add description to all packages
+- update cargo toml for all crates
+- use arcs for wrapping strings (temp)
+- cargo xtask fmt
+- new ci
+- cargo xtask fmt
+- apply clippy suggestions
+- applying clippy lints
+- fixing clippy lints
+- fix typos
+- remove unused dependencies
+- cleaned up cache loop
+- stream api folder structure
+- order change message data field renaming
+- order change message data field renaming
+- order place date will be a proper date time object
+- type renaming
+- tests for market book cache
+- wip subscribe
+- wip
+- rearrange the stream types
+- rpc adapter cleanup
+- cleanup stream API data types

--- a/crates/betfair-typegen/CHANGELOG.md
+++ b/crates/betfair-typegen/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/betfair-types/CHANGELOG.md
+++ b/crates/betfair-types/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.1.0...betfair-types-v0.1.1) - 2024-12-24
+
+### Other
+
+- use local readme

--- a/crates/betfair-xml-parser/CHANGELOG.md
+++ b/crates/betfair-xml-parser/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]


### PR DESCRIPTION
## 🤖 New release
* `betfair-adapter`: 0.1.0 -> 0.1.1
* `betfair-types`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `betfair-typegen`: 0.1.0 -> 0.1.1
* `betfair-xml-parser`: 0.1.0 -> 0.1.1
* `betfair-cert-gen`: 0.1.0 -> 0.1.1
* `betfair-rpc-server-mock`: 0.1.0 -> 0.1.1
* `betfair-stream-api`: 0.1.0 -> 0.1.1
* `betfair-stream-types`: 0.1.0 -> 0.1.1
* `betfair-stream-server-mock`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `betfair-adapter`
<blockquote>

## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.1.0...betfair-adapter-v0.1.1) - 2024-12-24

### Added

- betfair requests can be made concurrently via request objects
- :art: Added xtask subscribe to market command (#7)
- example on how to connnect to betfair
- refactored stream api
- can instantiate stream api by just importing a trait
- rpc server mock separated out
- created handicap type
- wrapper/helper for subscribing to markets
- stream API can do a handshake
- stream api can connect
- custom types for some specific betfair types
- stream api tls and non-tls connections
- initial stream api processor

### Fixed

- re-export internal request types
- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
- misbehaving heartbeat strategy

### Other

- add description to all packages
- update cargo toml for all crates
- use arcs for wrapping strings (temp)
- remove unnecessary `async` keywords
- `build_request` is no longer async
- cargo xtask fmt
- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
- new ci
- identity parsing tests
- remove circular dependencies
- cargo xtask fmt
- betfair urls have default jurisdiction
- applying clippy lints
- fixing clippy lints
- remove unused dependencies
- improved error handling and added sesseion token refresh logic
- cargo fmt & cargo clippy
- added utilities for wiring up mocks
- added utilities for wiring up mocks
- fix broken tests
- rename "rpc adapter" to just "adapter"
- readme update
- cleanup
- update readme, docs and templates
- root for custom Betfair adapter
</blockquote>

## `betfair-types`
<blockquote>

## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.1.0...betfair-types-v0.1.1) - 2024-12-24

### Other

- use local readme
</blockquote>

## `betfair-cert-gen`
<blockquote>

## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.1.0...betfair-cert-gen-v0.1.1) - 2024-12-24

### Added

- utilities for generating certificates for Betfair

### Fixed

- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
- :construction: Fix linting warnings in the codebase (#4)

### Other

- add description to all packages
- update cargo toml for all crates
- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
- new ci
- cargo xtask fmt
- fixing clippy lints
- readme update
- cleanup
- update readme, docs and templates
- root for custom Betfair adapter
</blockquote>

## `betfair-rpc-server-mock`
<blockquote>

## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.1.0...betfair-rpc-server-mock-v0.1.1) - 2024-12-24

### Added

- refactored stream api
- can instantiate stream api by just importing a trait
- rpc server mock separated out

### Fixed

- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))

### Other

- add description to all packages
- update cargo toml for all crates
- use arcs for wrapping strings (temp)
- remove unnecessary `async` keywords
- fix broken test
- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
- new ci
- add utilities to model errror responses
- remove circular dependencies
- rpc mock will validate login credentials
- applying clippy lints
- fixing clippy lints
- remove unused dependencies
- fix broken test
- added utilities for wiring up mocks
- added utilities for wiring up mocks
- added utilities for wiring up mocks
- readme update
- cleanup
- update readme, docs and templates
- root for custom Betfair adapter
</blockquote>

## `betfair-stream-api`
<blockquote>

## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.1.0...betfair-stream-api-v0.1.1) - 2024-12-24

### Added

- can build local cache from data
- expose cache primitives
- getter for runners and market_id in OrderBookCache
- using `backoff` crate for retrying the connection to the stream
- utilities for generating certificates for Betfair
- failure to authenticate will trigger a metadata update
- proper handling for tls connector
- example on how to connnect to betfair
- refactored stream api
- can instantiate stream api by just importing a trait
- rpc server mock separated out
- order subscriber specialization
- re-expose internal cache types
- created handicap type
- fix auto-reconnection
- wrapper/helper for subscribing to markets
- cache for stream listener
- init order book cache
- stream market book cache
- available cache structure
- stream API can do a handshake
- stream api can connect
- stream api tls and non-tls connections
- initial stream api processor
- new empty crate for betfair stream api

### Fixed

- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
- misbehaving heartbeat strategy

### Other

- add description to all packages
- update cargo toml for all crates
- use arcs for wrapping strings (temp)
- expose the available book data
- minor cleanup
- bump deps
- cargo xtask fmt
- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
- typo fix
- new ci
- remove circular dependencies
- cargo xtask fmt
- orderbok cache refactor
- using pin-project crate
- remove unnecessary async
- apply clippy suggestions
- applying clippy lints
- fixing clippy lints
- fix typos
- remove unused dependencies
- cargo xtask fmt
- remove redundant broadcast channel
- add tests for stream api connection
- cleaned up cache loop
- improved error handling and added sesseion token refresh logic
- handshake handled by a custom stream impl
- stream api folder structure
- cargo fmt & cargo clippy
- tls stream will no longer be multiplexed
- added utilities for wiring up mocks
- exposing order cache
- exposing order cache
- init background reconnection structure
- fix broken tests
- type renaming
- simplified `raw_stream` code
- tests for market book cache
- wip subscribe
- cargo make fmt
- fix broken tests
- wip
- readme update
- cleanup
- update readme, docs and templates
- root for custom Betfair adapter
</blockquote>

## `betfair-stream-types`
<blockquote>

## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.1.0...betfair-stream-types-v0.1.1) - 2024-12-24

### Added

- created handicap type
- wrapper/helper for subscribing to markets
- cache for stream listener
- init order book cache
- stream market book cache
- custom types for some specific betfair types
- initial stream api processor
- streaming API types

### Fixed

- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
- :construction: Fix linting warnings in the codebase (#4)

### Other

- use local readme
- add description to all packages
- update cargo toml for all crates
- use arcs for wrapping strings (temp)
- cargo xtask fmt
- new ci
- cargo xtask fmt
- apply clippy suggestions
- applying clippy lints
- fixing clippy lints
- fix typos
- remove unused dependencies
- cleaned up cache loop
- stream api folder structure
- order change message data field renaming
- order change message data field renaming
- order place date will be a proper date time object
- type renaming
- tests for market book cache
- wip subscribe
- wip
- rearrange the stream types
- rpc adapter cleanup
- cleanup stream API data types
</blockquote>

## `betfair-stream-server-mock`
<blockquote>

## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-server-mock-v0.1.0...betfair-stream-server-mock-v0.1.1) - 2024-12-24

### Added

- stream api will not crash if certificate cell is initialized
- proper handling for tls connector
- refactored stream api
- created handicap type
- fix auto-reconnection
- wrapper/helper for subscribing to markets

### Fixed

- :bug: Fix for the default feature of integration-test (#9)
- fix resolve eyre::Result handling in rust type parsing & warnings fixes ([#6](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/6))
- misbehaving heartbeat strategy

### Other

- add description to all packages
- update cargo toml for all crates
- use arcs for wrapping strings (temp)
- Update README.md ([#5](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/5))
- new ci
- remove circular dependencies
- fixing clippy lints
- remove unused dependencies
- stream api folder structure
- cargo fmt & cargo clippy
- cargo make fmt
- fix broken tests
- readme update
- cleanup
- update readme, docs and templates
- root for custom Betfair adapter
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).