### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "betfair-adapter"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "betfair-types",
  "eyre",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-cert-gen"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "eyre",
  "rcgen",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-rpc-server-mock"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "betfair-adapter",
  "betfair-types",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-api"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "backoff",
  "betfair-adapter",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-server-mock"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "betfair-adapter",
  "betfair-rpc-server-mock",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-types"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "betfair-types",
  "chrono",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-typegen"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "betfair-xml-parser",
  "eyre",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-types"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "betfair-typegen",
  "chrono",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-xml-parser"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "log",
  "rstest",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-market"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-orders"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -3391,7 +3391,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "betfair-cert-gen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/*", "xtask"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Roberts Pumpurs <roberts@pumpurlabs.com>"]
 repository = "https://github.com/roberts-pumpurs/betfair-adapter-rs"
 homepage = "https://github.com/roberts-pumpurs/betfair-adapter-rs"

--- a/crates/betfair-adapter/CHANGELOG.md
+++ b/crates/betfair-adapter/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.1.2...betfair-adapter-v0.2.0) - 2025-04-06
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.1.0...betfair-adapter-v0.1.1) - 2024-12-24
 
 ### Added

--- a/crates/betfair-cert-gen/CHANGELOG.md
+++ b/crates/betfair-cert-gen/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.1.2...betfair-cert-gen-v0.2.0) - 2025-04-06
+
+### Other
+
+- remove unused deps & switch to stable
+- update deps
+
 ## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.1.0...betfair-cert-gen-v0.1.1) - 2024-12-24
 
 ### Added

--- a/crates/betfair-rpc-server-mock/CHANGELOG.md
+++ b/crates/betfair-rpc-server-mock/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.1.2...betfair-rpc-server-mock-v0.2.0) - 2025-04-06
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.1.0...betfair-rpc-server-mock-v0.1.1) - 2024-12-24
 
 ### Added

--- a/crates/betfair-stream-api/CHANGELOG.md
+++ b/crates/betfair-stream-api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.1.2...betfair-stream-api-v0.2.0) - 2025-04-06
+
+### Other
+
+- remove unused deps & switch to stable
+
 ## [0.1.2](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.1.1...betfair-stream-api-v0.1.2) - 2024-12-24
 
 ### Other

--- a/crates/betfair-stream-server-mock/CHANGELOG.md
+++ b/crates/betfair-stream-server-mock/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-server-mock-v0.1.2...betfair-stream-server-mock-v0.2.0) - 2025-04-06
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.2](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-server-mock-v0.1.1...betfair-stream-server-mock-v0.1.2) - 2024-12-24
 
 ### Other

--- a/crates/betfair-stream-types/CHANGELOG.md
+++ b/crates/betfair-stream-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.1.2...betfair-stream-types-v0.2.0) - 2025-04-06
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.1.0...betfair-stream-types-v0.1.1) - 2024-12-24
 
 ### Added

--- a/crates/betfair-typegen/CHANGELOG.md
+++ b/crates/betfair-typegen/CHANGELOG.md
@@ -6,3 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.1.2...betfair-typegen-v0.2.0) - 2025-04-06
+
+### Fixed
+
+- naming
+- inconsistency in exec report error code

--- a/crates/betfair-types/CHANGELOG.md
+++ b/crates/betfair-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.1.2...betfair-types-v0.2.0) - 2025-04-06
+
+### Other
+
+- remove unused deps & switch to stable
+
 ## [0.1.2](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.1.1...betfair-types-v0.1.2) - 2024-12-24
 
 ### Other

--- a/crates/betfair-xml-parser/CHANGELOG.md
+++ b/crates/betfair-xml-parser/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.1.2...betfair-xml-parser-v0.2.0) - 2025-04-06
+
+### Other
+
+- update Cargo.toml dependencies


### PR DESCRIPTION



## 🤖 New release

* `betfair-xml-parser`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `betfair-typegen`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `betfair-types`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `betfair-adapter`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `betfair-cert-gen`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `betfair-rpc-server-mock`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `betfair-stream-types`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `betfair-stream-api`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `betfair-stream-server-mock`: 0.1.2 -> 0.2.0 (✓ API compatible changes)

### ⚠ `betfair-types` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ExecutionReportErrorCode::ErrorInMatcher 0 -> 1 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1258
  variant ExecutionReportErrorCode::ProcessedWithErrors 1 -> 2 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1261
  variant ExecutionReportErrorCode::BetActionError 2 -> 3 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1264
  variant ExecutionReportErrorCode::InvalidAccountState 3 -> 4 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1267
  variant ExecutionReportErrorCode::InvalidWalletStatus 4 -> 5 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1270
  variant ExecutionReportErrorCode::InsufficientFunds 5 -> 6 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1273
  variant ExecutionReportErrorCode::LossLimitExceeded 6 -> 7 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1276
  variant ExecutionReportErrorCode::MarketSuspended 7 -> 8 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1279
  variant ExecutionReportErrorCode::MarketNotOpenForBetting 8 -> 9 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1282
  variant ExecutionReportErrorCode::DuplicateTransaction 9 -> 10 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1285
  variant ExecutionReportErrorCode::InvalidOrder 10 -> 11 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1288
  variant ExecutionReportErrorCode::InvalidMarketId 11 -> 12 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1291
  variant ExecutionReportErrorCode::PermissionDenied 12 -> 13 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1294
  variant ExecutionReportErrorCode::DuplicateBetids 13 -> 14 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1297
  variant ExecutionReportErrorCode::NoActionRequired 14 -> 15 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1300
  variant ExecutionReportErrorCode::ServiceUnavailable 15 -> 16 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1303
  variant ExecutionReportErrorCode::RejectedByRegulator 16 -> 17 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1306
  variant ExecutionReportErrorCode::NoChasing 17 -> 18 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1309
  variant ExecutionReportErrorCode::RegulatorIsNotAvailable 18 -> 19 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1312
  variant ExecutionReportErrorCode::TooManyInstructions 19 -> 20 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1315
  variant ExecutionReportErrorCode::InvalidMarketVersion 20 -> 21 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1318
  variant ExecutionReportErrorCode::EventExposureLimitExceeded 21 -> 22 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1321
  variant ExecutionReportErrorCode::EventMatchedExposureLimitExceeded 22 -> 23 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1324
  variant ExecutionReportErrorCode::EventBlocked 23 -> 24 in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1327

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant ExecutionReportErrorCode:ErrorInOrder in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1255

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  ExecutionReportErrorCode::ErrorInMatcher moved from position 1 to 2, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1258
  ExecutionReportErrorCode::ProcessedWithErrors moved from position 2 to 3, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1261
  ExecutionReportErrorCode::BetActionError moved from position 3 to 4, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1264
  ExecutionReportErrorCode::InvalidAccountState moved from position 4 to 5, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1267
  ExecutionReportErrorCode::InvalidWalletStatus moved from position 5 to 6, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1270
  ExecutionReportErrorCode::InsufficientFunds moved from position 6 to 7, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1273
  ExecutionReportErrorCode::LossLimitExceeded moved from position 7 to 8, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1276
  ExecutionReportErrorCode::MarketSuspended moved from position 8 to 9, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1279
  ExecutionReportErrorCode::MarketNotOpenForBetting moved from position 9 to 10, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1282
  ExecutionReportErrorCode::DuplicateTransaction moved from position 10 to 11, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1285
  ExecutionReportErrorCode::InvalidOrder moved from position 11 to 12, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1288
  ExecutionReportErrorCode::InvalidMarketId moved from position 12 to 13, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1291
  ExecutionReportErrorCode::PermissionDenied moved from position 13 to 14, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1294
  ExecutionReportErrorCode::DuplicateBetids moved from position 14 to 15, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1297
  ExecutionReportErrorCode::NoActionRequired moved from position 15 to 16, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1300
  ExecutionReportErrorCode::ServiceUnavailable moved from position 16 to 17, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1303
  ExecutionReportErrorCode::RejectedByRegulator moved from position 17 to 18, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1306
  ExecutionReportErrorCode::NoChasing moved from position 18 to 19, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1309
  ExecutionReportErrorCode::RegulatorIsNotAvailable moved from position 19 to 20, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1312
  ExecutionReportErrorCode::TooManyInstructions moved from position 20 to 21, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1315
  ExecutionReportErrorCode::InvalidMarketVersion moved from position 21 to 22, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1318
  ExecutionReportErrorCode::EventExposureLimitExceeded moved from position 22 to 23, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1321
  ExecutionReportErrorCode::EventMatchedExposureLimitExceeded moved from position 23 to 24, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1324
  ExecutionReportErrorCode::EventBlocked moved from position 24 to 25, in /tmp/.tmpLnPzhe/betfair-adapter-rs/target/semver-checks/local-betfair_types-0_1_2-01666ec060466c14/target/debug/build/betfair-types-88f2cfb844682c82/out/sports_aping.rs:1327
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `betfair-xml-parser`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.1.2...betfair-xml-parser-v0.2.0) - 2025-04-06

### Other

- update Cargo.toml dependencies
</blockquote>

## `betfair-typegen`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.1.2...betfair-typegen-v0.2.0) - 2025-04-06

### Fixed

- naming
- inconsistency in exec report error code
</blockquote>

## `betfair-types`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.1.2...betfair-types-v0.2.0) - 2025-04-06

### Other

- remove unused deps & switch to stable
</blockquote>

## `betfair-adapter`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.1.2...betfair-adapter-v0.2.0) - 2025-04-06

### Other

- update Cargo.toml dependencies
</blockquote>

## `betfair-cert-gen`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.1.2...betfair-cert-gen-v0.2.0) - 2025-04-06

### Other

- remove unused deps & switch to stable
- update deps
</blockquote>

## `betfair-rpc-server-mock`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.1.2...betfair-rpc-server-mock-v0.2.0) - 2025-04-06

### Other

- update Cargo.toml dependencies
</blockquote>

## `betfair-stream-types`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.1.2...betfair-stream-types-v0.2.0) - 2025-04-06

### Other

- update Cargo.toml dependencies
</blockquote>

## `betfair-stream-api`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.1.2...betfair-stream-api-v0.2.0) - 2025-04-06

### Other

- remove unused deps & switch to stable
</blockquote>

## `betfair-stream-server-mock`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-server-mock-v0.1.2...betfair-stream-server-mock-v0.2.0) - 2025-04-06

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).