### PR TITLE
chore: release v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "betfair-adapter"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "betfair-types",
  "eyre",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-cert-gen"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "eyre",
  "rcgen",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-rpc-server-mock"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "betfair-adapter",
  "betfair-types",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "backoff",
  "betfair-adapter",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-server-mock"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "betfair-adapter",
  "betfair-rpc-server-mock",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "betfair-types",
  "chrono",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-typegen"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "betfair-xml-parser",
  "eyre",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "betfair-typegen",
  "chrono",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-xml-parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "log",
  "rstest",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-market"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-orders"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -3391,7 +3391,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "betfair-cert-gen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/*", "xtask"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Roberts Pumpurs <roberts@pumpurlabs.com>"]
 repository = "https://github.com/roberts-pumpurs/betfair-adapter-rs"
 homepage = "https://github.com/roberts-pumpurs/betfair-adapter-rs"

--- a/crates/betfair-typegen/CHANGELOG.md
+++ b/crates/betfair-typegen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.2.0...betfair-typegen-v0.2.1) - 2025-04-06
+
+### Added
+
+- add extra missing error param to sportsaping
+
 ## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.1.2...betfair-typegen-v0.2.0) - 2025-04-06
 
 ### Fixed

--- a/crates/betfair-xml-parser/CHANGELOG.md
+++ b/crates/betfair-xml-parser/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.2.0...betfair-xml-parser-v0.2.1) - 2025-04-06
+
+### Other
+
+- misc formatting
+
 ## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.1.2...betfair-xml-parser-v0.2.0) - 2025-04-06
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `betfair-xml-parser`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `betfair-typegen`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `betfair-types`: 0.2.0 -> 0.2.1
* `betfair-adapter`: 0.2.0 -> 0.2.1
* `betfair-cert-gen`: 0.2.0 -> 0.2.1
* `betfair-rpc-server-mock`: 0.2.0 -> 0.2.1
* `betfair-stream-types`: 0.2.0 -> 0.2.1
* `betfair-stream-api`: 0.2.0 -> 0.2.1
* `betfair-stream-server-mock`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `betfair-xml-parser`

<blockquote>

## [0.2.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.2.0...betfair-xml-parser-v0.2.1) - 2025-04-06

### Other

- misc formatting
</blockquote>

## `betfair-typegen`

<blockquote>

## [0.2.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.2.0...betfair-typegen-v0.2.1) - 2025-04-06

### Added

- add extra missing error param to sportsaping
</blockquote>

## `betfair-types`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.1.2...betfair-types-v0.2.0) - 2025-04-06

### Other

- remove unused deps & switch to stable
</blockquote>

## `betfair-adapter`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.1.2...betfair-adapter-v0.2.0) - 2025-04-06

### Other

- update Cargo.toml dependencies
</blockquote>

## `betfair-cert-gen`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.1.2...betfair-cert-gen-v0.2.0) - 2025-04-06

### Other

- remove unused deps & switch to stable
- update deps
</blockquote>

## `betfair-rpc-server-mock`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.1.2...betfair-rpc-server-mock-v0.2.0) - 2025-04-06

### Other

- update Cargo.toml dependencies
</blockquote>

## `betfair-stream-types`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.1.2...betfair-stream-types-v0.2.0) - 2025-04-06

### Other

- update Cargo.toml dependencies
</blockquote>

## `betfair-stream-api`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.1.2...betfair-stream-api-v0.2.0) - 2025-04-06

### Other

- remove unused deps & switch to stable
</blockquote>

## `betfair-stream-server-mock`

<blockquote>

## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-server-mock-v0.1.2...betfair-stream-server-mock-v0.2.0) - 2025-04-06

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).