### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "betfair-adapter"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "betfair-types",
  "eyre",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-cert-gen"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "eyre",
  "rcgen",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-rpc-server-mock"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "betfair-adapter",
  "betfair-types",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-api"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "backon",
  "betfair-adapter",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-types"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "betfair-types",
  "chrono",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-typegen"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "betfair-xml-parser",
  "eyre",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-types"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "betfair-typegen",
  "chrono",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-xml-parser"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "log",
  "rstest",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-market"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-orders"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -3144,7 +3144,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "betfair-cert-gen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/*", "xtask"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Roberts Pumpurs <roberts@pumpurlabs.com>"]
 repository = "https://github.com/roberts-pumpurs/betfair-adapter-rs"
 homepage = "https://github.com/roberts-pumpurs/betfair-adapter-rs"

--- a/crates/betfair-adapter/CHANGELOG.md
+++ b/crates/betfair-adapter/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.2.1...betfair-adapter-v0.3.0) - 2025-04-20
+
+### Added
+
+- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
+
 ## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.1.2...betfair-adapter-v0.2.0) - 2025-04-06
 
 ### Other

--- a/crates/betfair-cert-gen/CHANGELOG.md
+++ b/crates/betfair-cert-gen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.2.1...betfair-cert-gen-v0.3.0) - 2025-04-20
+
+### Added
+
+- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
+
 ## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.1.2...betfair-cert-gen-v0.2.0) - 2025-04-06
 
 ### Other

--- a/crates/betfair-rpc-server-mock/CHANGELOG.md
+++ b/crates/betfair-rpc-server-mock/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.2.1...betfair-rpc-server-mock-v0.3.0) - 2025-04-20
+
+### Added
+
+- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
+
 ## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.1.2...betfair-rpc-server-mock-v0.2.0) - 2025-04-06
 
 ### Other

--- a/crates/betfair-stream-api/CHANGELOG.md
+++ b/crates/betfair-stream-api/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.2.1...betfair-stream-api-v0.3.0) - 2025-04-20
+
+### Added
+
+- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))

--- a/crates/betfair-stream-types/CHANGELOG.md
+++ b/crates/betfair-stream-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.2.1...betfair-stream-types-v0.3.0) - 2025-04-20
+
+### Added
+
+- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
+
 ## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.1.2...betfair-stream-types-v0.2.0) - 2025-04-06
 
 ### Other

--- a/crates/betfair-typegen/CHANGELOG.md
+++ b/crates/betfair-typegen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.2.1...betfair-typegen-v0.3.0) - 2025-04-20
+
+### Added
+
+- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
+
 ## [0.2.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.2.0...betfair-typegen-v0.2.1) - 2025-04-06
 
 ### Added

--- a/crates/betfair-types/CHANGELOG.md
+++ b/crates/betfair-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.2.1...betfair-types-v0.3.0) - 2025-04-20
+
+### Added
+
+- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
+
 ## [0.2.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.1.2...betfair-types-v0.2.0) - 2025-04-06
 
 ### Other

--- a/crates/betfair-xml-parser/CHANGELOG.md
+++ b/crates/betfair-xml-parser/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.2.1...betfair-xml-parser-v0.3.0) - 2025-04-20
+
+### Added
+
+- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
+
 ## [0.2.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.2.0...betfair-xml-parser-v0.2.1) - 2025-04-06
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `betfair-xml-parser`: 0.2.1 -> 0.3.0 (✓ API compatible changes)
* `betfair-typegen`: 0.2.1 -> 0.3.0 (✓ API compatible changes)
* `betfair-types`: 0.2.1 -> 0.3.0 (✓ API compatible changes)
* `betfair-adapter`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `betfair-cert-gen`: 0.2.1 -> 0.3.0 (✓ API compatible changes)
* `betfair-rpc-server-mock`: 0.2.1 -> 0.3.0 (✓ API compatible changes)
* `betfair-stream-types`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `betfair-stream-api`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `betfair-adapter` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct betfair_adapter::AuthenticatedBetfairRpcProvider, previously in file /tmp/.tmpu2m1ME/betfair-adapter/src/provider.rs:23
  struct betfair_adapter::UnauthenticatedBetfairRpcProvider, previously in file /tmp/.tmpu2m1ME/betfair-adapter/src/provider.rs:20
```

### ⚠ `betfair-stream-types` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum betfair_stream_types::response::status_message::StatusCode, previously in file /tmp/.tmpu2m1ME/betfair-stream-types/src/response/status_message.rs:58

--- failure struct_with_pub_fields_changed_type: struct with pub fields became an enum or union ---

Description:
A struct with pub fields became an enum or union, breaking accesses to its public fields.
        ref: https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_with_pub_fields_changed_type.ron

Failed in:
  struct betfair_stream_types::response::status_message::StatusMessage became enum in file /tmp/.tmpyd4VBN/betfair-adapter-rs/crates/betfair-stream-types/src/response/status_message.rs:21
```

### ⚠ `betfair-stream-api` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum betfair_stream_api::cache::tracker::IncomingMessage, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/cache/tracker/mod.rs:34
  enum betfair_stream_api::ExternalUpdates, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/connection/mod.rs:73
  enum betfair_stream_api::CodecError, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/tls_sream.rs:136
  enum betfair_stream_api::CacheEnabledMessages, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/connection/mod.rs:82
  enum betfair_stream_api::HeartbeatStrategy, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/connection/builder.rs:15
  enum betfair_stream_api::StreamError, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/error.rs:6
  enum betfair_stream_api::MetadataUpdates, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/connection/mod.rs:95

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/feature_missing.ron

Failed in:
  feature integration-test in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  StreamState::calculate_updates, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/cache/tracker/mod.rs:62

--- failure pub_static_missing: pub static is missing ---

Description:
A public static is missing, renamed, or made private.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/pub_static_missing.ron

Failed in:
  CERTIFICATE in file /tmp/.tmpu2m1ME/betfair-stream-api/src/lib.rs:42

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct betfair_stream_api::StreamApiBuilder, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/connection/builder.rs:25
  struct betfair_stream_api::StreamApi, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/connection/mod.rs:23
  struct betfair_stream_api::OrderSubscriber, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/cache/order_subscriber.rs:11
  struct betfair_stream_api::OrderBookCache, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/cache/primitives/orderbook_cache.rs:15
  struct betfair_stream_api::MarketBookCache, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/cache/primitives/market_book_cache.rs:18
  struct betfair_stream_api::MarketSubscriber, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/cache/market_subscriber.rs:13

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_missing.ron

Failed in:
  trait betfair_stream_api::BetfairProviderExt, previously in file /tmp/.tmpu2m1ME/betfair-stream-api/src/lib.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `betfair-xml-parser`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.2.1...betfair-xml-parser-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>

## `betfair-typegen`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.2.1...betfair-typegen-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>

## `betfair-types`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.2.1...betfair-types-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>

## `betfair-adapter`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.2.1...betfair-adapter-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>

## `betfair-cert-gen`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.2.1...betfair-cert-gen-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>

## `betfair-rpc-server-mock`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.2.1...betfair-rpc-server-mock-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>

## `betfair-stream-types`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.2.1...betfair-stream-types-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>

## `betfair-stream-api`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.2.1...betfair-stream-api-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).