### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "betfair-adapter"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "backon",
  "betfair-types",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-cert-gen"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "eyre",
  "rcgen",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-rpc-server-mock"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "betfair-adapter",
  "betfair-types",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "backon",
  "betfair-adapter",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-types"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "betfair-types",
  "chrono",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-typegen"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "betfair-xml-parser",
  "eyre",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-types"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "betfair-typegen",
  "chrono",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-xml-parser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "log",
  "rstest",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-market"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-orders"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -3145,7 +3145,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "betfair-cert-gen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/*", "xtask"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Roberts Pumpurs <roberts@pumpurlabs.com>"]
 repository = "https://github.com/roberts-pumpurs/betfair-adapter-rs"
 homepage = "https://github.com/roberts-pumpurs/betfair-adapter-rs"

--- a/crates/betfair-adapter/CHANGELOG.md
+++ b/crates/betfair-adapter/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.4.0...betfair-adapter-v0.4.1) - 2025-04-21
+
+### Other
+
+- typos fix
+
 ## [0.4.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.3.0...betfair-adapter-v0.4.0) - 2025-04-20
 
 ### Added

--- a/crates/betfair-cert-gen/CHANGELOG.md
+++ b/crates/betfair-cert-gen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.4.0...betfair-cert-gen-v0.4.1) - 2025-04-21
+
+### Other
+
+- typos fix
+
 ## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.2.1...betfair-cert-gen-v0.3.0) - 2025-04-20
 
 ### Added

--- a/crates/betfair-rpc-server-mock/CHANGELOG.md
+++ b/crates/betfair-rpc-server-mock/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.4.0...betfair-rpc-server-mock-v0.4.1) - 2025-04-21
+
+### Other
+
+- typos fix
+- fix keep alive test
+
 ## [0.4.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.3.0...betfair-rpc-server-mock-v0.4.0) - 2025-04-20
 
 ### Added

--- a/crates/betfair-stream-api/CHANGELOG.md
+++ b/crates/betfair-stream-api/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.4.0...betfair-stream-api-v0.4.1) - 2025-04-21
+
+### Added
+
+- add extra derive macros
+
+### Other
+
+- typos fix
+
 ## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.2.1...betfair-stream-api-v0.3.0) - 2025-04-20
 
 ### Added

--- a/crates/betfair-stream-api/src/cache/tracker/mod.rs
+++ b/crates/betfair-stream-api/src/cache/tracker/mod.rs
@@ -13,7 +13,7 @@ use self::order_stream_tracker::OrderStreamTracker;
 use super::primitives::{MarketBookCache, OrderBookCache};
 
 /// Separate stream struct to hold market/order caches
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StreamState {
     pub stream_id: Option<u64>,
     pub update_clk: Option<Clock>,

--- a/crates/betfair-stream-api/src/lib.rs
+++ b/crates/betfair-stream-api/src/lib.rs
@@ -48,6 +48,7 @@ use tokio_util::{
 /// # Type Parameters
 ///
 /// - `T`: A type that implements `MessageProcessor`, used to handle incoming `ResponseMessage` objects.
+#[derive(Debug, Clone)]
 pub struct BetfairStreamBuilder<T: MessageProcessor> {
     /// betfair client
     pub client: BetfairRpcClient<Unauthenticated>,
@@ -60,6 +61,7 @@ pub struct BetfairStreamBuilder<T: MessageProcessor> {
 /// Handle to a running Betfair Streaming API client.
 ///
 /// Provides channels to send requests (`send_to_stream`) and receive processed messages (`sink`).
+#[derive(Debug)]
 pub struct BetfairStreamClient<T: MessageProcessor> {
     /// send a message to the Betfair stream
     pub send_to_stream: Sender<RequestMessage>,
@@ -70,6 +72,7 @@ pub struct BetfairStreamClient<T: MessageProcessor> {
 /// Default `MessageProcessor` implementation that maintains market and order caches.
 ///
 /// It updates an internal `StreamState` to apply incremental updates to market and order books.
+#[derive(Debug, Clone)]
 pub struct Cache {
     state: StreamState,
 }
@@ -129,6 +132,7 @@ impl MessageProcessor for Cache {
 }
 
 /// `MessageProcessor` that forwards raw `ResponseMessage` objects without transformation.
+#[derive(Debug)]
 pub struct Forwarder;
 impl MessageProcessor for Forwarder {
     type Output = ResponseMessage;

--- a/crates/betfair-typegen/CHANGELOG.md
+++ b/crates/betfair-typegen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.4.0...betfair-typegen-v0.4.1) - 2025-04-21
+
+### Other
+
+- typos fix
+
 ## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.2.1...betfair-typegen-v0.3.0) - 2025-04-20
 
 ### Added

--- a/crates/betfair-xml-parser/CHANGELOG.md
+++ b/crates/betfair-xml-parser/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.4.0...betfair-xml-parser-v0.4.1) - 2025-04-21
+
+### Other
+
+- typos fix
+
 ## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.2.1...betfair-xml-parser-v0.3.0) - 2025-04-20
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `betfair-xml-parser`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `betfair-typegen`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `betfair-types`: 0.4.0 -> 0.4.1
* `betfair-adapter`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `betfair-cert-gen`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `betfair-rpc-server-mock`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `betfair-stream-types`: 0.4.0 -> 0.4.1
* `betfair-stream-api`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `betfair-xml-parser`

<blockquote>

## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.4.0...betfair-xml-parser-v0.4.1) - 2025-04-21

### Other

- typos fix
</blockquote>

## `betfair-typegen`

<blockquote>

## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.4.0...betfair-typegen-v0.4.1) - 2025-04-21

### Other

- typos fix
</blockquote>

## `betfair-types`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.2.1...betfair-types-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>

## `betfair-adapter`

<blockquote>

## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.4.0...betfair-adapter-v0.4.1) - 2025-04-21

### Other

- typos fix
</blockquote>

## `betfair-cert-gen`

<blockquote>

## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.4.0...betfair-cert-gen-v0.4.1) - 2025-04-21

### Other

- typos fix
</blockquote>

## `betfair-rpc-server-mock`

<blockquote>

## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.4.0...betfair-rpc-server-mock-v0.4.1) - 2025-04-21

### Other

- typos fix
- fix keep alive test
</blockquote>

## `betfair-stream-types`

<blockquote>

## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.2.1...betfair-stream-types-v0.3.0) - 2025-04-20

### Added

- stream api rewrite ([#31](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/31))
</blockquote>

## `betfair-stream-api`

<blockquote>

## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.4.0...betfair-stream-api-v0.4.1) - 2025-04-21

### Added

- add extra derive macros

### Other

- typos fix
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).