### PR TITLE
feat: getter for total_matched in MarketBookCache

### DIFF
--- a/crates/betfair-stream-api/src/cache/primitives/market_book_cache.rs
+++ b/crates/betfair-stream-api/src/cache/primitives/market_book_cache.rs
@@ -202,6 +202,12 @@ impl MarketBookCache {
     pub const fn market_id(&self) -> &MarketId {
         &self.market_id
     }
+
+    /// Returns the total amount matched across the market.
+    #[must_use]
+    pub const fn total_matched(&self) -> Size {
+        self.total_matched
+    }
 }
 
 #[cfg(test)]
@@ -244,6 +250,7 @@ mod tests {
             init.update_cache(change.clone(), Utc::now(), true);
             assert!(init.active);
             assert_eq!(init.total_matched, change.total_value.unwrap_or_default());
+            assert_eq!(init.total_matched(), change.total_value.unwrap_or_default());
         }
     }
 


### PR DESCRIPTION
**Describe the changes**
Adds a public getter function for the `total_matched` field of MarketBookCache.

**Related Issue(s)**
None

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Similar method [already exists](https://github.com/roberts-pumpurs/betfair-adapter-rs/blob/77a967693ccd8b1db608cdf4c762acd53f77980f/crates/betfair-stream-api/src/cache/primitives/runner_book_cache.rs#L127-L130) on RunnerBookCache:
