### PR TITLE
feat: make SelectionId and other i64 newtypes Copy

### DIFF
--- a/crates/betfair-typegen/src/gen_v1/data_types.rs
+++ b/crates/betfair-typegen/src/gen_v1/data_types.rs
@@ -223,8 +223,18 @@ impl<T: CodeInjector> GenV1GeneratorStrategy<T> {
         if types_to_skip.contains(&type_alias.name.0.as_str()) {
             return None;
         }
+
+        let extra = if type_alias.data_type.as_str().eq("i64") {
+            quote! {
+                #[derive(Copy)]
+            }
+        } else {
+            quote! {}
+        };
+
         Some(quote! {
             #type_alias_derives
+            #extra
             pub struct #name (pub #data_type);
         })
     }


### PR DESCRIPTION
**Describe the changes**
Changes the codegen to make any i64 newtypes derive Copy, in particular SelectionId.

This just saves me having to use `.clone()` on SelectionId when it's just an i64 under the hood.

If there is a sensible place to add a test for this let me know, but otherwise I checked the output and it now looks like this for `SelectionId`:

```rust
#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
#[serde(rename_all = "camelCase")]
#[derive(Copy)]
pub struct SelectionId(pub i64);
```

**Related Issue(s)**
None

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
I've made the change similar to how extra attributes are added [for structs](https://github.com/roberts-pumpurs/betfair-adapter-rs/blob/1327d92be9fa3cdfaa04f2b85819851adf92060d/crates/betfair-typegen/src/gen_v1/data_types.rs#L146-L163).
