### PR TITLE
chore: `cargo xtask fmt` updates and reduce warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ exclude = [
 # self_named_module_files = "allow"
 
 [workspace.lints.rust]
-missing_docs = { level = "warn", priority = -1 }
+# missing_docs = { level = "warn", priority = -1 }
 rust_2018_idioms = { level = "deny", priority = 0 }
 unreachable_pub = { level = "warn", priority = -1 }
 unused_imports = { level = "warn", priority = -1 }

--- a/crates/betfair-adapter/src/provider.rs
+++ b/crates/betfair-adapter/src/provider.rs
@@ -1,7 +1,6 @@
 pub(crate) mod authenticated;
 mod unauthenticated;
 
-
 use crate::{SessionToken, secret, urls};
 
 #[derive(Debug, Clone)]

--- a/crates/betfair-rpc-server-mock/src/lib.rs
+++ b/crates/betfair-rpc-server-mock/src/lib.rs
@@ -56,8 +56,10 @@ impl Server {
     }
 
     pub async fn new_with_stream_url(stream_url: CustomUrl<Stream>) -> Self {
-        let mut settings = MockSettings::default();
-        settings.stream_url = stream_url;
+        let settings = MockSettings {
+            stream_url,
+            ..Default::default()
+        };
         Self::new_with_settings(settings).await
     }
 
@@ -107,7 +109,8 @@ impl Server {
     }
 
     #[must_use]
-    pub fn betfair_config<'a>(
+    #[allow(clippy::type_complexity)]
+    pub fn betfair_config(
         &self,
         secrets_provider: SecretProvider,
     ) -> BetfairConfigBuilder<

--- a/crates/betfair-rpc-server-mock/src/urlencoded_matcher.rs
+++ b/crates/betfair-rpc-server-mock/src/urlencoded_matcher.rs
@@ -12,11 +12,10 @@ impl FormEncodedBodyMatcher {
 
 impl Match for FormEncodedBodyMatcher {
     fn matches(&self, req: &Request) -> bool {
-        if let Ok(body) = String::from_utf8(req.body.clone()) {
-            if let Ok(decoded_body) = serde_urlencoded::from_str::<Vec<(String, String)>>(&body) {
+        if let Ok(body) = String::from_utf8(req.body.clone())
+            && let Ok(decoded_body) = serde_urlencoded::from_str::<Vec<(String, String)>>(&body) {
                 return decoded_body == self.expected;
             }
-        }
         false
     }
 }

--- a/crates/betfair-rpc-server-mock/src/urlencoded_matcher.rs
+++ b/crates/betfair-rpc-server-mock/src/urlencoded_matcher.rs
@@ -13,9 +13,10 @@ impl FormEncodedBodyMatcher {
 impl Match for FormEncodedBodyMatcher {
     fn matches(&self, req: &Request) -> bool {
         if let Ok(body) = String::from_utf8(req.body.clone())
-            && let Ok(decoded_body) = serde_urlencoded::from_str::<Vec<(String, String)>>(&body) {
-                return decoded_body == self.expected;
-            }
+            && let Ok(decoded_body) = serde_urlencoded::from_str::<Vec<(String, String)>>(&body)
+        {
+            return decoded_body == self.expected;
+        }
         false
     }
 }

--- a/crates/betfair-stream-api/src/cache/primitives/market_book_cache.rs
+++ b/crates/betfair-stream-api/src/cache/primitives/market_book_cache.rs
@@ -68,7 +68,7 @@ impl MarketBookCache {
         let mut calculate_total_matched = false;
         if let Some(rc) = market_change.runner_change {
             for runner_change in rc {
-                let Some(selection_id) = runner_change.id.clone() else {
+                let Some(selection_id) = runner_change.id else {
                     continue;
                 };
                 let runner = self
@@ -139,7 +139,7 @@ impl MarketBookCache {
         self.market_definition = Some(Box::new(market_definition.clone()));
 
         for runner_definition in market_definition.runners {
-            let selection_id = runner_definition.id.clone();
+            let selection_id = runner_definition.id;
             let Some(selection_id) = selection_id else {
                 continue;
             };
@@ -156,7 +156,7 @@ impl MarketBookCache {
 
     /// Adds a runner from a change.
     fn add_runner_from_change(&mut self, runner_change: RunnerChange) {
-        let Some(selection_id) = runner_change.id.clone() else {
+        let Some(selection_id) = runner_change.id else {
             return;
         };
         let key = (selection_id, runner_change.handicap);
@@ -168,7 +168,7 @@ impl MarketBookCache {
 
     /// Adds a runner from a definition.
     fn add_runner_from_definition(&mut self, runner_definition: RunnerDefinition) {
-        let Some(selection_id) = runner_definition.id.clone() else {
+        let Some(selection_id) = runner_definition.id else {
             return;
         };
         let key = (selection_id, runner_definition.handicap);

--- a/crates/betfair-stream-api/src/cache/primitives/orderbook_cache.rs
+++ b/crates/betfair-stream-api/src/cache/primitives/orderbook_cache.rs
@@ -48,9 +48,9 @@ impl OrderBookCache {
             for runner_change in order_runner_change {
                 let runner = self
                     .runners
-                    .entry((runner_change.id.clone(), runner_change.handicap))
+                    .entry((runner_change.id, runner_change.handicap))
                     .or_insert_with(|| {
-                        OrderBookRunner::new(self.market_id.clone(), runner_change.id.clone())
+                        OrderBookRunner::new(self.market_id.clone(), runner_change.id)
                     });
 
                 if let Some(ml) = runner_change.matched_lays {

--- a/crates/betfair-stream-api/src/cache/primitives/runner_book_cache.rs
+++ b/crates/betfair-stream-api/src/cache/primitives/runner_book_cache.rs
@@ -80,7 +80,7 @@ impl RunnerBookCache {
     }
 
     pub fn new_from_runner_definition(runner_definition: RunnerDefinition) -> eyre::Result<Self> {
-        let Some(selection_id) = runner_definition.id.clone() else {
+        let Some(selection_id) = runner_definition.id else {
             bail!("Invalid selection id");
         };
         let definition = Some(runner_definition);

--- a/crates/betfair-stream-api/src/cache/tracker/mod.rs
+++ b/crates/betfair-stream-api/src/cache/tracker/mod.rs
@@ -22,8 +22,8 @@ pub struct StreamState {
     pub initial_clock: Option<InitialClock>,
     pub time_created: chrono::DateTime<chrono::Utc>,
     pub time_updated: chrono::DateTime<chrono::Utc>,
-    pub market_stream_tracker: MarketStreamTracker,
-    pub order_stream_tracker: OrderStreamTracker,
+    pub(crate) market_stream_tracker: MarketStreamTracker,
+    pub(crate) order_stream_tracker: OrderStreamTracker,
 }
 
 pub enum Updates<'a> {

--- a/crates/betfair-stream-api/src/cache/tracker/mod.rs
+++ b/crates/betfair-stream-api/src/cache/tracker/mod.rs
@@ -115,6 +115,7 @@ impl StreamState {
         self.update_clk(msg);
     }
 
+    #[allow(unused)]
     pub(crate) fn clear_stale_cache(&mut self, publish_time: chrono::DateTime<chrono::Utc>) {
         self.market_stream_tracker.clear_stale_cache(publish_time);
         self.order_stream_tracker.clear_stale_cache(publish_time);

--- a/crates/betfair-stream-api/src/lib.rs
+++ b/crates/betfair-stream-api/src/lib.rs
@@ -109,22 +109,22 @@ impl MessageProcessor for Cache {
                 Some(CachedMessage::Connection(connection_message))
             }
             ResponseMessage::MarketChange(market_change_message) => {
-                let data = self
+                
+
+                self
                     .state
                     .market_change_update(market_change_message)
                     .map(|markets| markets.into_iter().cloned().collect::<Vec<_>>())
-                    .map(CachedMessage::MarketChange);
-
-                data
+                    .map(CachedMessage::MarketChange)
             }
             ResponseMessage::OrderChange(order_change_message) => {
-                let data = self
+                
+
+                self
                     .state
                     .order_change_update(order_change_message)
                     .map(|markets| markets.into_iter().cloned().collect::<Vec<_>>())
-                    .map(CachedMessage::OrderChange);
-
-                data
+                    .map(CachedMessage::OrderChange)
             }
             ResponseMessage::Status(status_message) => Some(CachedMessage::Status(status_message)),
         }

--- a/crates/betfair-stream-api/src/lib.rs
+++ b/crates/betfair-stream-api/src/lib.rs
@@ -108,24 +108,16 @@ impl MessageProcessor for Cache {
             ResponseMessage::Connection(connection_message) => {
                 Some(CachedMessage::Connection(connection_message))
             }
-            ResponseMessage::MarketChange(market_change_message) => {
-                
-
-                self
-                    .state
-                    .market_change_update(market_change_message)
-                    .map(|markets| markets.into_iter().cloned().collect::<Vec<_>>())
-                    .map(CachedMessage::MarketChange)
-            }
-            ResponseMessage::OrderChange(order_change_message) => {
-                
-
-                self
-                    .state
-                    .order_change_update(order_change_message)
-                    .map(|markets| markets.into_iter().cloned().collect::<Vec<_>>())
-                    .map(CachedMessage::OrderChange)
-            }
+            ResponseMessage::MarketChange(market_change_message) => self
+                .state
+                .market_change_update(market_change_message)
+                .map(|markets| markets.into_iter().cloned().collect::<Vec<_>>())
+                .map(CachedMessage::MarketChange),
+            ResponseMessage::OrderChange(order_change_message) => self
+                .state
+                .order_change_update(order_change_message)
+                .map(|markets| markets.into_iter().cloned().collect::<Vec<_>>())
+                .map(CachedMessage::OrderChange),
             ResponseMessage::Status(status_message) => Some(CachedMessage::Status(status_message)),
         }
     }

--- a/crates/betfair-stream-types/src/response/market_change_message.rs
+++ b/crates/betfair-stream-types/src/response/market_change_message.rs
@@ -358,7 +358,7 @@ pub struct RunnerDefinition {
 /// Implements comparison for `RunnerDefinition`.
 impl PartialOrd for RunnerDefinition {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.sort_priority.partial_cmp(&other.sort_priority)
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/betfair-typegen/src/aping_ast.rs
+++ b/crates/betfair-typegen/src/aping_ast.rs
@@ -45,7 +45,9 @@ impl From<Interface> for Aping {
             rpc_calls: HashMap::new(),
             data_types: HashMap::new(),
         };
-        let aping = val.items.iter().fold(aping_default, |mut aping, x| {
+        
+
+        val.items.iter().fold(aping_default, |mut aping, x| {
             match *x {
                 betfair_xml_parser::InterfaceItems::Description(ref x) => {
                     aping.insert_top_level_docs(x);
@@ -60,9 +62,7 @@ impl From<Interface> for Aping {
                 betfair_xml_parser::InterfaceItems::Operation(ref x) => aping.insert_operation(x),
             }
             aping
-        });
-
-        aping
+        })
     }
 }
 
@@ -409,7 +409,8 @@ mod prism_impls {
 
     impl Prism<Vec<Comment>> for betfair_xml_parser::operation::Operation {
         fn lense(&self) -> Vec<Comment> {
-            let doc_comment = self
+            
+            self
                 .values
                 .iter()
                 .filter_map(|x| match *x {
@@ -419,8 +420,7 @@ mod prism_impls {
                     betfair_xml_parser::operation::OperationItem::Parameters(_) => None,
                 })
                 .map(Comment::new)
-                .collect();
-            doc_comment
+                .collect()
         }
     }
 
@@ -451,7 +451,8 @@ mod prism_impls {
 
     impl Prism<Vec<Comment>> for &betfair_xml_parser::common::Parameter {
         fn lense(&self) -> Vec<Comment> {
-            let doc_comments = self
+            
+            self
                 .items
                 .iter()
                 .filter_map(|x| match *x {
@@ -461,8 +462,7 @@ mod prism_impls {
                     betfair_xml_parser::common::ParameterItem::ValidValues(_) => None,
                 })
                 .map(Comment::new)
-                .collect::<Vec<_>>();
-            doc_comments
+                .collect::<Vec<_>>()
         }
     }
 

--- a/crates/betfair-typegen/src/aping_ast.rs
+++ b/crates/betfair-typegen/src/aping_ast.rs
@@ -45,7 +45,6 @@ impl From<Interface> for Aping {
             rpc_calls: HashMap::new(),
             data_types: HashMap::new(),
         };
-        
 
         val.items.iter().fold(aping_default, |mut aping, x| {
             match *x {
@@ -409,9 +408,7 @@ mod prism_impls {
 
     impl Prism<Vec<Comment>> for betfair_xml_parser::operation::Operation {
         fn lense(&self) -> Vec<Comment> {
-            
-            self
-                .values
+            self.values
                 .iter()
                 .filter_map(|x| match *x {
                     betfair_xml_parser::operation::OperationItem::Description(ref x) => {
@@ -451,9 +448,7 @@ mod prism_impls {
 
     impl Prism<Vec<Comment>> for &betfair_xml_parser::common::Parameter {
         fn lense(&self) -> Vec<Comment> {
-            
-            self
-                .items
+            self.items
                 .iter()
                 .filter_map(|x| match *x {
                     betfair_xml_parser::common::ParameterItem::Description(ref x) => {

--- a/crates/betfair-typegen/src/gen_v1/injector.rs
+++ b/crates/betfair-typegen/src/gen_v1/injector.rs
@@ -52,6 +52,7 @@ impl CodeInjectorV1 {
             module_level_preamble: quote! {
                 use std::fmt::Debug;
                 use serde::{Serialize, Deserialize};
+                #[allow(unused_imports)]
                 use chrono::{DateTime, Utc};
                 use typed_builder::TypedBuilder;
             },

--- a/crates/betfair-typegen/src/gen_v1/top_level_preamble.rs
+++ b/crates/betfair-typegen/src/gen_v1/top_level_preamble.rs
@@ -7,9 +7,6 @@ use super::injector::CodeInjector;
 impl<T: CodeInjector> GenV1GeneratorStrategy<T> {
     pub(crate) fn generate_transport_layer(&self) -> TokenStream {
         quote! {
-            use std::future::Future;
-            use serde::{Serialize, de::DeserializeOwned};
-
             pub trait BetfairRpcRequest {
                 type Res;
                 type Error;
@@ -22,7 +19,7 @@ impl<T: CodeInjector> GenV1GeneratorStrategy<T> {
 
             use rust_decimal::{Decimal, prelude::FromPrimitive};
             use serde::de::{self, Visitor};
-            use serde::{Deserialize, Deserializer};
+            use serde::{Deserializer};
 
             // Define a custom visitor struct to handle different types
             struct DecimalOptionVisitor;

--- a/crates/betfair-typegen/src/generator/output.rs
+++ b/crates/betfair-typegen/src/generator/output.rs
@@ -89,9 +89,10 @@ impl GeneratedOutput {
 
         if !status.success() {
             tracing::error!(?file_path, "cannot format file");
-            return Err(io::Error::other(
-                format!("rustfmt failed for {}", file_path.display()),
-            ));
+            return Err(io::Error::other(format!(
+                "rustfmt failed for {}",
+                file_path.display()
+            )));
         }
         Ok(())
     }

--- a/crates/betfair-typegen/src/generator/output.rs
+++ b/crates/betfair-typegen/src/generator/output.rs
@@ -89,8 +89,7 @@ impl GeneratedOutput {
 
         if !status.success() {
             tracing::error!(?file_path, "cannot format file");
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 format!("rustfmt failed for {}", file_path.display()),
             ));
         }

--- a/crates/betfair-types/src/price.rs
+++ b/crates/betfair-types/src/price.rs
@@ -74,6 +74,8 @@ impl Price {
 
     /// This function is unsafe because it does not check if the price is within the Betfair
     /// boundaries. Use `Price::new` instead.
+    /// # Safety
+    /// The caller must ensure that the price is within the Betfair boundaries.
     #[must_use]
     pub const unsafe fn new_unchecked(price: rust_decimal::Decimal) -> Self {
         Self(price)


### PR DESCRIPTION
**Describe the changes**
I wanted to reduce warnings and get all the build tasks passing, to make it easier to create future PRs.

I did the following:
- Ran `cargo xtask fmt` multiple times to get all build checks passing.
- Disabled "missing documentation" warnings at the workspace level (it is still enabled in other places at crate level as before). These warnings were making it hard to find the more important warnings. As an alternative I could (probably with the help of Claude) add all the missing documentation. But I'm not sure that's necessary right now.
- Some of the imports in the generated code were unnecessary, so I removed them. Others were sometimes unnecessary depending on what was being generated so I added `#[allow(unused_imports)]` on them. This was to remove the warnings.
- I fixed another warning about field/type visibility missmatch by making the field visibility match the type.
- There are still some other code warnings, but I didn't look into them too closely, or I didn't want to make an assumption on how to fix them

Let me know if you're not happy with any of these.

Btw, thanks for the library!

**Related Issue(s)**
None

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
None