### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "betfair-adapter"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "backon",
  "betfair-types",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-cert-gen"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "eyre",
  "rcgen",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-rpc-server-mock"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "betfair-adapter",
  "betfair-types",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-api"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "backon",
  "betfair-adapter",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-types"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "betfair-types",
  "chrono",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-typegen"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "betfair-xml-parser",
  "eyre",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-types"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "betfair-typegen",
  "chrono",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-xml-parser"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "log",
  "rstest",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-market"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-orders"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -3145,7 +3145,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "betfair-cert-gen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/*", "xtask"]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Roberts Pumpurs <roberts@pumpurlabs.com>"]
 repository = "https://github.com/roberts-pumpurs/betfair-adapter-rs"
 homepage = "https://github.com/roberts-pumpurs/betfair-adapter-rs"

--- a/crates/betfair-adapter/CHANGELOG.md
+++ b/crates/betfair-adapter/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.5.2...betfair-adapter-v0.6.0) - 2025-09-20
+
+### Other
+
+- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
+
 ## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.4.0...betfair-adapter-v0.4.1) - 2025-04-21
 
 ### Other

--- a/crates/betfair-rpc-server-mock/CHANGELOG.md
+++ b/crates/betfair-rpc-server-mock/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.5.2...betfair-rpc-server-mock-v0.6.0) - 2025-09-20
+
+### Other
+
+- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
+
 ## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.4.0...betfair-rpc-server-mock-v0.4.1) - 2025-04-21
 
 ### Other

--- a/crates/betfair-stream-api/CHANGELOG.md
+++ b/crates/betfair-stream-api/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.5.2...betfair-stream-api-v0.6.0) - 2025-09-20
+
+### Added
+
+- make `Price`, `Handicap` and `Position` all Copy ([#64](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/64))
+
+### Other
+
+- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
+
 ## [0.5.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.5.0...betfair-stream-api-v0.5.1) - 2025-09-18
 
 ### Added

--- a/crates/betfair-stream-types/CHANGELOG.md
+++ b/crates/betfair-stream-types/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.5.2...betfair-stream-types-v0.6.0) - 2025-09-20
+
+### Added
+
+- make `Price`, `Handicap` and `Position` all Copy ([#64](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/64))
+
+### Other
+
+- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
+
 ## [0.3.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.2.1...betfair-stream-types-v0.3.0) - 2025-04-20
 
 ### Added

--- a/crates/betfair-typegen/CHANGELOG.md
+++ b/crates/betfair-typegen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.5.2...betfair-typegen-v0.6.0) - 2025-09-20
+
+### Other
+
+- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
+
 ## [0.5.2](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.5.1...betfair-typegen-v0.5.2) - 2025-09-18
 
 ### Added

--- a/crates/betfair-types/CHANGELOG.md
+++ b/crates/betfair-types/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.5.2...betfair-types-v0.6.0) - 2025-09-20
+
+### Added
+
+- make `Price`, `Handicap` and `Position` all Copy ([#64](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/64))
+
+### Other
+
+- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
+
 ## [0.5.2](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.5.1...betfair-types-v0.5.2) - 2025-09-18
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `betfair-xml-parser`: 0.5.2 -> 0.6.0
* `betfair-typegen`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `betfair-types`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `betfair-adapter`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `betfair-cert-gen`: 0.5.2 -> 0.6.0
* `betfair-rpc-server-mock`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `betfair-stream-types`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `betfair-stream-api`: 0.5.2 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `betfair-stream-api` breaking changes

```text
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field market_stream_tracker of struct StreamState, previously in file /tmp/.tmpBUBNjG/betfair-stream-api/src/cache/tracker/mod.rs:25
  field order_stream_tracker of struct StreamState, previously in file /tmp/.tmpBUBNjG/betfair-stream-api/src/cache/tracker/mod.rs:26

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field StreamState.market_stream_tracker in file /tmp/.tmpJR4YSM/betfair-adapter-rs/crates/betfair-stream-api/src/cache/tracker/mod.rs:17
  field StreamState.order_stream_tracker in file /tmp/.tmpJR4YSM/betfair-adapter-rs/crates/betfair-stream-api/src/cache/tracker/mod.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `betfair-xml-parser`

<blockquote>

## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.4.0...betfair-xml-parser-v0.4.1) - 2025-04-21

### Other

- typos fix
</blockquote>

## `betfair-typegen`

<blockquote>

## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.5.2...betfair-typegen-v0.6.0) - 2025-09-20

### Other

- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
</blockquote>

## `betfair-types`

<blockquote>

## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.5.2...betfair-types-v0.6.0) - 2025-09-20

### Added

- make `Price`, `Handicap` and `Position` all Copy ([#64](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/64))

### Other

- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
</blockquote>

## `betfair-adapter`

<blockquote>

## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.5.2...betfair-adapter-v0.6.0) - 2025-09-20

### Other

- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
</blockquote>

## `betfair-cert-gen`

<blockquote>

## [0.4.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.4.0...betfair-cert-gen-v0.4.1) - 2025-04-21

### Other

- typos fix
</blockquote>

## `betfair-rpc-server-mock`

<blockquote>

## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.5.2...betfair-rpc-server-mock-v0.6.0) - 2025-09-20

### Other

- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
</blockquote>

## `betfair-stream-types`

<blockquote>

## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.5.2...betfair-stream-types-v0.6.0) - 2025-09-20

### Added

- make `Price`, `Handicap` and `Position` all Copy ([#64](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/64))

### Other

- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
</blockquote>

## `betfair-stream-api`

<blockquote>

## [0.6.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.5.2...betfair-stream-api-v0.6.0) - 2025-09-20

### Added

- make `Price`, `Handicap` and `Position` all Copy ([#64](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/64))

### Other

- `cargo xtask fmt` updates and reduce warnings ([#63](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/63))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).