### PR TITLE
chore: release v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "betfair-adapter"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "backon",
  "betfair-rpc-server-mock",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-cert-gen"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "eyre",
  "rcgen",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-rpc-server-mock"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "betfair-adapter",
  "betfair-types",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-api"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "backon",
  "betfair-adapter",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-stream-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "betfair-types",
  "chrono",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-typegen"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "betfair-xml-parser",
  "eyre",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "betfair-typegen",
  "chrono",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "betfair-xml-parser"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "log",
  "rstest",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-market"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "stream-api-subscribe-to-orders"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "betfair-adapter",
  "betfair-stream-api",
@@ -3348,7 +3348,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "betfair-cert-gen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*", "examples/*", "xtask"]
 
 [workspace.package]
 rust-version = "1.91"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Roberts Pumpurs <roberts@pumpurlabs.com>"]
 repository = "https://github.com/roberts-pumpurs/betfair-adapter-rs"
 homepage = "https://github.com/roberts-pumpurs/betfair-adapter-rs"

--- a/crates/betfair-adapter/CHANGELOG.md
+++ b/crates/betfair-adapter/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.7.0...betfair-adapter-v0.7.1) - 2026-02-15
+
+### Other
+
+- add benchmark comparison workflow for PRs ([#113](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/113))
+
 ## [0.6.3](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.6.2...betfair-adapter-v0.6.3) - 2025-11-03
 
 ### Other

--- a/crates/betfair-stream-api/CHANGELOG.md
+++ b/crates/betfair-stream-api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.7.0...betfair-stream-api-v0.7.1) - 2026-02-15
+
+### Other
+
+- add benchmark comparison workflow for PRs ([#113](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/113))
+
 ## [0.7.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.6.8...betfair-stream-api-v0.7.0) - 2026-02-14
 
 ### Added

--- a/crates/betfair-stream-types/CHANGELOG.md
+++ b/crates/betfair-stream-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.7.0...betfair-stream-types-v0.7.1) - 2026-02-15
+
+### Other
+
+- add benchmark comparison workflow for PRs ([#113](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/113))
+
 ## [0.7.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.6.8...betfair-stream-types-v0.7.0) - 2026-02-14
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `betfair-xml-parser`: 0.7.0 -> 0.7.1
* `betfair-typegen`: 0.7.0 -> 0.7.1
* `betfair-types`: 0.7.0 -> 0.7.1
* `betfair-adapter`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `betfair-rpc-server-mock`: 0.7.0 -> 0.7.1
* `betfair-cert-gen`: 0.7.0 -> 0.7.1
* `betfair-stream-types`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `betfair-stream-api`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `betfair-xml-parser`

<blockquote>

## [0.6.3](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-xml-parser-v0.6.2...betfair-xml-parser-v0.6.3) - 2025-11-03

### Other

- remove rust_decimal feature, only use floats ([#86](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/86))
</blockquote>

## `betfair-typegen`

<blockquote>

## [0.7.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-typegen-v0.6.8...betfair-typegen-v0.7.0) - 2026-02-14

### Fixed

- allow certain fields to be missing as witnessed in live data ([#108](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/108))

### Other

- remove NumericPrimitives as no longer needed ([#110](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/110))
</blockquote>

## `betfair-types`

<blockquote>

## [0.7.0](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-types-v0.6.8...betfair-types-v0.7.0) - 2026-02-14

### Fixed

- allow certain fields to be missing as witnessed in live data ([#108](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/108))

### Other

- remove NumericPrimitives as no longer needed ([#110](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/110))
</blockquote>

## `betfair-adapter`

<blockquote>

## [0.7.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-adapter-v0.7.0...betfair-adapter-v0.7.1) - 2026-02-15

### Other

- add benchmark comparison workflow for PRs ([#113](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/113))
</blockquote>

## `betfair-rpc-server-mock`

<blockquote>

## [0.6.8](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-rpc-server-mock-v0.6.7...betfair-rpc-server-mock-v0.6.8) - 2025-12-07

### Fixed

- size cancelled and matcheddate not mandatory ([#104](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/104))
</blockquote>

## `betfair-cert-gen`

<blockquote>

## [0.6.3](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-cert-gen-v0.6.2...betfair-cert-gen-v0.6.3) - 2025-11-03

### Other

- remove rust_decimal feature, only use floats ([#86](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/86))
</blockquote>

## `betfair-stream-types`

<blockquote>

## [0.7.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-types-v0.7.0...betfair-stream-types-v0.7.1) - 2026-02-15

### Other

- add benchmark comparison workflow for PRs ([#113](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/113))
</blockquote>

## `betfair-stream-api`

<blockquote>

## [0.7.1](https://github.com/roberts-pumpurs/betfair-adapter-rs/compare/betfair-stream-api-v0.7.0...betfair-stream-api-v0.7.1) - 2026-02-15

### Other

- add benchmark comparison workflow for PRs ([#113](https://github.com/roberts-pumpurs/betfair-adapter-rs/pull/113))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.7.1 across all packages
  * Updated changelogs to document new benchmark comparison workflow for pull requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->