### PR TITLE
fix(betfair-adapter): stop leaking session token through tracing logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "serde_urlencoded",
  "test-log",
  "tokio",
+ "tracing",
  "tracing-subscriber",
  "url",
  "wiremock",

--- a/crates/betfair-adapter/src/provider/authenticated.rs
+++ b/crates/betfair-adapter/src/provider/authenticated.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::marker::PhantomData;
 
 use betfair_types::keep_alive;
@@ -14,7 +15,7 @@ impl BetfairRpcClient<Authenticated> {
     ///
     /// # Returns
     /// A result containing either the response or an `ApiError`.
-    #[tracing::instrument(skip_all, ret, err, fields(req = ?request))]
+    #[tracing::instrument(skip_all, err, fields(req = ?request))]
     pub async fn send_request<T>(&self, request: T) -> Result<T::Res, ApiError>
     where
         T: BetfairRpcRequest + serde::Serialize + core::fmt::Debug,
@@ -79,7 +80,7 @@ impl BetfairRpcClient<Authenticated> {
     /// session time is 24 hours. Therefore, you should request Keep Alive within this time to
     /// prevent session expiry. If you don't call Keep Alive within the specified timeout period,
     /// the session will expire. Session times aren't determined or extended based on API activity.
-    #[tracing::instrument(skip_all, ret, err)]
+    #[tracing::instrument(skip_all, err)]
     pub fn keep_alive(&self) -> Result<BetfairRequest<keep_alive::Response, ()>, ApiError> {
         let endpoint = self.keep_alive.url();
         let client = self.state.authenticated_client.clone();
@@ -96,7 +97,7 @@ impl BetfairRpcClient<Authenticated> {
     }
 
     /// You can use Logout to terminate your existing session.
-    #[tracing::instrument(skip_all, ret, err)]
+    #[tracing::instrument(skip_all, err)]
     pub fn logout(&self) -> Result<BetfairRequest<keep_alive::Response, ()>, ApiError> {
         let endpoint = self.logout.url();
         let client = self.state.authenticated_client.clone();
@@ -114,12 +115,49 @@ impl BetfairRpcClient<Authenticated> {
 }
 
 /// Encalpsulated HTTP request for the Betfair API
-#[derive(Debug)]
 pub struct BetfairRequest<T, E> {
     request: reqwest::Request,
     client: reqwest::Client,
     result: PhantomData<T>,
     err: PhantomData<E>,
+}
+
+/// HTTP header names whose values must never be written to logs.
+///
+/// `reqwest`/`http` normalise header names to lowercase, so comparing against
+/// these lowercase literals is effectively case-insensitive.
+const SENSITIVE_HEADERS: &[&str] = &["x-authentication", "authorization", "cookie", "set-cookie"];
+
+// Manual `Debug` impl: the derived one prints the `client`, whose default
+// headers carry the `x-authentication` session token, leaking it into logs.
+// We omit the `client` entirely and redact sensitive headers of the request.
+impl<T, E> fmt::Debug for BetfairRequest<T, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BetfairRequest")
+            .field("method", self.request.method())
+            .field("url", &self.request.url().as_str())
+            .field("headers", &RedactedHeaders(self.request.headers()))
+            .finish_non_exhaustive()
+    }
+}
+
+/// Wraps a `HeaderMap` to redact the values of sensitive headers when formatted
+/// with `Debug`.
+struct RedactedHeaders<'a>(&'a reqwest::header::HeaderMap);
+
+impl fmt::Debug for RedactedHeaders<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut map = formatter.debug_map();
+        for (name, value) in self.0 {
+            if SENSITIVE_HEADERS.contains(&name.as_str()) {
+                map.entry(&name.as_str(), &"<redacted>");
+            } else {
+                map.entry(&name.as_str(), &value);
+            }
+        }
+        map.finish()
+    }
 }
 
 impl<T, E> BetfairRequest<T, E> {
@@ -214,4 +252,53 @@ where
 
     let error = serde_json::from_slice::<E>(bytes)?;
     Ok(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOKEN: &str = "super-secret-session-token";
+
+    /// Builds a `BetfairRequest` whose client *and* request both carry the
+    /// session token, mirroring how `logged_in_client` sets the default header.
+    fn request_carrying_token() -> BetfairRequest<(), ()> {
+        let mut default_headers = reqwest::header::HeaderMap::new();
+        default_headers.insert(
+            "X-Authentication",
+            reqwest::header::HeaderValue::from_static(TOKEN),
+        );
+        let client = reqwest::Client::builder()
+            .use_rustls_tls()
+            .default_headers(default_headers)
+            .build()
+            .expect("client builds");
+
+        let request = client
+            .get("https://api.betfair.com/keepAlive")
+            .header("X-Authentication", TOKEN)
+            .build()
+            .expect("request builds");
+
+        BetfairRequest {
+            request,
+            client,
+            result: PhantomData,
+            err: PhantomData,
+        }
+    }
+
+    #[test]
+    fn debug_does_not_leak_session_token() {
+        let formatted = format!("{:?}", request_carrying_token());
+
+        assert!(
+            !formatted.contains(TOKEN),
+            "session token leaked through Debug:\n{formatted}"
+        );
+        assert!(
+            formatted.contains("<redacted>"),
+            "expected redacted header marker in Debug output:\n{formatted}"
+        );
+    }
 }

--- a/crates/betfair-rpc-server-mock/Cargo.toml
+++ b/crates/betfair-rpc-server-mock/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 serde_urlencoded.workspace = true
 
 [dev-dependencies]
+tracing.workspace = true
 tracing-subscriber.workspace = true
 rstest.workspace = true
 tokio.workspace = true

--- a/crates/betfair-rpc-server-mock/tests/integration/keep_alive.rs
+++ b/crates/betfair-rpc-server-mock/tests/integration/keep_alive.rs
@@ -1,5 +1,36 @@
-use betfair_rpc_server_mock::Server;
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use betfair_rpc_server_mock::{SESSION_TOKEN, Server};
 use rstest::rstest;
+use tracing_subscriber::fmt::MakeWriter;
+
+/// A `MakeWriter` that appends all emitted log bytes into a shared buffer,
+/// so a test can inspect what `tracing` actually wrote.
+#[derive(Clone)]
+struct BufferWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for BufferWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("log buffer poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for BufferWriter {
+    type Writer = BufferWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
 
 #[rstest]
 #[test_log::test(tokio::test)]
@@ -16,6 +47,47 @@ async fn keep_alive() {
     let client = server.client().await;
     let (client, _) = client.authenticate().await.unwrap();
     let ka = client.keep_alive().unwrap();
+    ka.execute()
+        .await
+        .unwrap()
+        .json_err()
+        .await
+        .unwrap()
+        .unwrap();
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn keep_alive_does_not_leak_session_token() {
+    let server = Server::new().await;
+
+    server
+        .mock_keep_alive()
+        .mount(&server.bf_api_mock_server)
+        .await;
+
+    let client = server.client().await;
+    let (client, _) = client.authenticate().await.unwrap();
+
+    // Capture INFO-level logs emitted only while building the keep-alive request.
+    // `keep_alive()` is synchronous, so a thread-local subscriber covers it fully.
+    let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(BufferWriter(Arc::clone(&buffer)))
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    let ka = tracing::subscriber::with_default(subscriber, || client.keep_alive().unwrap());
+
+    let logs = String::from_utf8(buffer.lock().expect("log buffer poisoned").clone())
+        .expect("logs are valid UTF-8");
+
+    assert!(
+        !logs.contains(SESSION_TOKEN),
+        "session token leaked into tracing logs:\n{logs}"
+    );
+
+    // Sanity-check the request still works end to end.
     ka.execute()
         .await
         .unwrap()


### PR DESCRIPTION
**Describe the changes**

`BetfairRpcClient<Authenticated>` logged the Betfair **session token in clear text** at `INFO` level. Anyone with access to the logs could replay an active session.

Root cause: `keep_alive`, `logout` and `send_request` were annotated with `#[tracing::instrument(skip_all, ret, err)]`. The `ret` option logs the return value — a `BetfairRequest` whose derived `Debug` printed the wrapped `reqwest::Client`. That client carries the `x-authentication` session token as a **default header**, so the token was emitted to every log sink:

```
INFO ... return=BetfairRequest {
  request: Request { method: GET, url: ".../keepAlive", headers: {} },
  client: Client { ... default_headers: { "x-authentication": "Wss...=" } },  <-- leak
  ...
}
```

The project's `redact::Secret<T>` does not help here: `tracing` renders an already-built `reqwest::Request`/`Client`, which knows nothing about redaction.

This PR fixes it at two levels:

- Drop the `ret` option from the `instrument` attributes on `keep_alive`, `logout` and `send_request`, so return values are no longer logged.
- Replace the derived `Debug` on `BetfairRequest` with a manual impl that:
  - omits the `client` field entirely (this is where the token actually lives, as a default header), and
  - redacts the values of sensitive request headers (`x-authentication`, `authorization`, `cookie`, `set-cookie`) as a defense-in-depth measure. Header names are compared in lowercase, matching how `http` normalises them.

This makes safety a property of the type rather than of logging discipline: even an intentional `dbg!(req)` stays safe. Scope is limited to `BetfairRequest`; `BetfairResponse` is intentionally left untouched.

**Related Issue(s)**

N/A — reported and fixed directly.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**

Tests added:

- Unit (`betfair-adapter`): asserts the session token never appears in the `Debug` output of a `BetfairRequest` and that the redaction marker is present.
- Integration (`betfair-rpc-server-mock`): captures the `tracing` output emitted while building a keep-alive request and fails if the session token leaks into the logs.

Verified locally (all green):

```
cargo clippy --workspace --locked -- -D warnings
cargo nextest run -p betfair-adapter -p betfair-rpc-server-mock
```

Follow-up (out of scope for this PR): `send_request` still carries `fields(req = ?request)`. This does **not** leak the session token, but on the error / empty-response paths the full typed request payload (e.g. order details) is rendered into the span context. Worth revisiting separately if request payloads are considered sensitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive authentication and session details are now redacted from request logs and debug output, reducing the risk of leaking tokens.
  * Keep-alive request logging was updated so session tokens are no longer exposed during normal operation.

* **Tests**
  * Added coverage to verify sensitive values do not appear in captured logs while requests still complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->