### PR TITLE
fix(betfair-adapter): retry only transient errors in authenticate()

### DIFF
--- a/crates/betfair-adapter/src/error.rs
+++ b/crates/betfair-adapter/src/error.rs
@@ -50,3 +50,12 @@ pub enum ApiError {
     #[error("Empty response from server")]
     EmptyResponse,
 }
+
+impl ApiError {
+    /// Transient errors worth retrying (network / HTTP transport).
+    /// Permanent errors (e.g. `BotLoginError`) are pointless to retry.
+    #[must_use]
+    pub fn is_retriable(&self) -> bool {
+        matches!(self, ApiError::ReqwestError(_))
+    }
+}

--- a/crates/betfair-adapter/src/provider/unauthenticated.rs
+++ b/crates/betfair-adapter/src/provider/unauthenticated.rs
@@ -33,22 +33,20 @@ impl BetfairRpcClient<Unauthenticated> {
         ApiError,
     > {
         let mut backoff = ExponentialBuilder::new().build();
-        let mut first_call = true;
         let (session_token, authenticated_client) = loop {
-            if !first_call {
-                // add exponential recovery
-                let next = backoff.next();
-                let Some(delay) = next else {
-                    return Err(ApiError::EyreError(eyre::eyre!("could not authenticate")));
-                };
-                sleep(delay).await;
+            match self.bot_log_in().await {
+                Ok(res) => break res,
+                Err(err) if err.is_retriable() => {
+                    let Some(delay) = backoff.next() else {
+                        // retries exhausted -> return the last error
+                        return Err(err);
+                    };
+                    tracing::warn!(?err, ?delay, "bot login failed, retrying");
+                    sleep(delay).await;
+                }
+                // permanent error -> no retries
+                Err(err) => return Err(err),
             }
-            first_call = true;
-            let Ok(res) = self.bot_log_in().await else {
-                continue;
-            };
-
-            break res;
         };
 
         let state = Authenticated {

--- a/crates/betfair-rpc-server-mock/tests/integration/authenticate.rs
+++ b/crates/betfair-rpc-server-mock/tests/integration/authenticate.rs
@@ -1,0 +1,118 @@
+use std::time::Duration;
+
+use betfair_adapter::jurisdiction::CustomUrl;
+use betfair_adapter::{ApiError, BetfairRpcClient};
+use betfair_rpc_server_mock::{BOT_LOGIN_URL, SESSION_TOKEN, Server};
+use betfair_types::bot_login::LoginError;
+use serde_json::json;
+use tokio::time::timeout;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+/// Happy path: valid credentials succeed on the first attempt and yield the
+/// session token from the (default) login mock.
+#[test_log::test(tokio::test)]
+async fn authenticate_success_returns_session_token() {
+    let server = Server::new().await;
+    let client = server.client().await;
+
+    let (client, _keep_alive) = timeout(Duration::from_secs(5), client.authenticate())
+        .await
+        .expect("must not hang")
+        .expect("authentication must succeed");
+
+    assert_eq!(client.session_token().0.expose_secret(), SESSION_TOKEN);
+}
+
+/// Happy path with recovery: a transient failure on the first attempt is
+/// retried, and the next attempt falls through to the default success mock.
+#[test_log::test(tokio::test)]
+async fn authenticate_transient_error_then_succeeds() {
+    let server = Server::new().await;
+
+    // Higher-priority mock that answers only the first request with a 500 and an
+    // empty (non-JSON) body, which surfaces as a transient error. It is consumed
+    // after one response, so the retry falls through to the default login mock.
+    Mock::given(method("POST"))
+        .and(path(BOT_LOGIN_URL))
+        .respond_with(ResponseTemplate::new(500))
+        .with_priority(1)
+        .up_to_n_times(1)
+        .named("Transient login failure")
+        .expect(1)
+        .mount(&server.bf_api_mock_server)
+        .await;
+
+    let client = server.client().await;
+    let (client, _keep_alive) = timeout(Duration::from_secs(10), client.authenticate())
+        .await
+        .expect("must not hang")
+        .expect("authentication must succeed after retry");
+
+    assert_eq!(client.session_token().0.expose_secret(), SESSION_TOKEN);
+}
+
+/// Invalid password is a permanent error: return immediately, no retries.
+#[test_log::test(tokio::test)]
+async fn authenticate_invalid_password_returns_immediately() {
+    let server = Server::new().await;
+
+    // Mount a failing mock with priority 1 over the default success login mock
+    // (it overrides the default). `.expect(1)` also verifies there are no retries.
+    Mock::given(method("POST"))
+        .and(path(BOT_LOGIN_URL))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({"loginStatus": "INVALID_USERNAME_OR_PASSWORD"})),
+        )
+        .with_priority(1)
+        .named("Login failure")
+        .expect(1)
+        .mount(&server.bf_api_mock_server)
+        .await;
+
+    let client = server.client().await;
+    let res = timeout(Duration::from_secs(5), client.authenticate())
+        .await
+        .expect("must not hang");
+
+    assert!(matches!(
+        res,
+        Err(ApiError::BotLoginError(
+            LoginError::InvalidUsernameOrPassword
+        ))
+    ));
+}
+
+/// Network error is transient: retry with backoff, then return the last error
+/// once the attempts are exhausted.
+#[test_log::test(tokio::test)]
+async fn authenticate_network_error_retries_then_returns() {
+    // Needed for `secrets_provider()` with the identity certificate.
+    let server = Server::new().await;
+
+    let secrets = server.secrets_provider();
+    let mut config = server.betfair_config(secrets);
+    // Reserve a loopback port and free it immediately, so every connection
+    // attempt is refused right away (more robust than a fixed magic port).
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    config.bot_login = CustomUrl::new(format!("http://{addr}/cert-login/").parse().unwrap());
+    let client = BetfairRpcClient::new_with_config(config).unwrap();
+
+    // Headroom for the backoff pauses (~1+2+4 s).
+    let start = std::time::Instant::now();
+    let res = timeout(Duration::from_secs(15), client.authenticate())
+        .await
+        .expect("must not hang");
+    let elapsed = start.elapsed();
+
+    assert!(matches!(res, Err(ApiError::ReqwestError(_))));
+    // Pin that retries actually happened: an immediate return (e.g. if the
+    // network error were misclassified as permanent) would skip the backoff.
+    assert!(
+        elapsed >= Duration::from_secs(3),
+        "expected backoff retries, but authenticate() returned in {elapsed:?}"
+    );
+}

--- a/crates/betfair-rpc-server-mock/tests/integration/main.rs
+++ b/crates/betfair-rpc-server-mock/tests/integration/main.rs
@@ -1,3 +1,4 @@
+mod authenticate;
 mod cancel_bets;
 mod keep_alive;
 mod list_market_book;


### PR DESCRIPTION
**Describe the changes**

`BetfairRpcClient::<Unauthenticated>::authenticate()` retried bot login on every failure in a tight loop with no delay. The `first_call` flag was reset to `true` on every iteration (it should have been `false`), so the `if !first_call { … sleep(delay) … }` backoff branch was never reached and the `backoff.next() == None` exhaustion path was unreachable. As a result, on a permanent failure (e.g. an invalid password) or a persistent network error, `authenticate()` spun forever — hammering the login endpoint with no delay (which risks a Betfair `TEMPORARY_BAN_TOO_MANY_REQUESTS` lockout) and never returning.

This PR removes the `first_call` flag entirely and replaces the loop with an error-classifying retry:

- adds `ApiError::is_retriable()` to distinguish transient (network / HTTP transport) errors from permanent ones;
- permanent errors (e.g. an invalid password surfacing as `BotLoginError`) return immediately, with no retries;
- transient errors (`ReqwestError`) are retried with exponential backoff, and once the attempts are exhausted the last error is returned instead of a generic `eyre` "could not authenticate".

**Related Issue(s)**

None — opening directly as a self-contained bug fix. Happy to file a tracking issue first if you prefer.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable). — doc comment on the new `ApiError::is_retriable()`.
- [x] The code follows Rust's style guidelines.

**Additional Context**

New integration tests in `crates/betfair-rpc-server-mock/tests/integration/authenticate.rs` cover:

- first-attempt success returns the session token;
- a transient failure on the first attempt is retried and then succeeds;
- an invalid password returns `BotLoginError` immediately, asserting a single login call (no retries);
- a network error (connection refused) retries with backoff and then returns `ReqwestError` once attempts are exhausted, asserting the backoff actually elapsed.

`cargo nextest run -p betfair-rpc-server-mock` is green (including the existing `keep_alive` test); `cargo xtask check` (clippy `-D warnings` + rustfmt) is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication now distinguishes temporary failures from permanent ones, improving retry behavior and error handling during sign-in.
  * Added broader authentication test coverage for successful logins, transient failures, invalid credentials, and connection issues.

* **Bug Fixes**
  * Login retries now stop immediately on non-retriable errors and continue backing off only when a retry is likely to help.
  * When retry limits are reached, the final relevant error is returned instead of a generic fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->